### PR TITLE
added interface-order template, and resolved resolvconf update bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,28 @@ applications to change nameserver settings on the fly.
 ```ruby
 node['resolvconf']['wipe-runtime-directory'] = false
 ```
+You can set a list of interfaces that you want to inherit the dns settings from. It creates the 
+interface-order file /etc/resolvconf/interface-order and builds it from the list.
+This enables you to control which additional dns servers if any are added from which interfaces.
+```ruby
+node['resolvconf']['interface-order'] = [
+  'lo.inet*',
+  'lo.dnsmasq',
+  'lo.pdnsd',
+  'lo.!(pdns|pdns-recursor)',
+  'lo',
+  'tun*',
+  'tap*',
+  'hso*',
+  'em+([0-9])?(_+([0-9]))*',
+  'p+([0-9])p+([0-9])?(_+([0-9]))*',
+  'eth*',
+  'ath*',
+  'wlan*',
+  'ppp*',
+  '*'
+]
+```
 
 
 ## Provider

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -42,7 +42,6 @@ default['resolvconf']['wipe-runtime-directory'] = false
 
 # these are the defaults, so lets place them here as to not disrupt the current state of things.
 default['resolvconf']['interface-order'] = [
-  'lo.inet*',
   'lo.dnsmasq',
   'lo.pdnsd',
   'lo.!(pdns|pdns-recursor)',

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -39,3 +39,22 @@ default['resolvconf']['clear-dns-from-interfaces'] = true
 # This is not enabled by default, as it breaks the dynamic capabilities for applications to change
 # nameserver entries.
 default['resolvconf']['wipe-runtime-directory'] = false
+
+# these are the defaults, so lets place them here as to not disrupt the current state of things.
+default['resolvconf']['interface-order'] = [
+  'lo.inet*',
+  'lo.dnsmasq',
+  'lo.pdnsd',
+  'lo.!(pdns|pdns-recursor)',
+  'lo',
+  'tun*',
+  'tap*',
+  'hso*',
+  'em+([0-9])?(_+([0-9]))*',
+  'p+([0-9])p+([0-9])?(_+([0-9]))*',
+  'eth*',
+  'ath*',
+  'wlan*',
+  'ppp*',
+  '*'
+]

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'me@chr4.org'
 license          'GNU Public License 3.0'
 description      'Installs/Configures resolvconf'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.2.6'
+version          '0.2.7'
 supports         'ubuntu', '>= 10.04'
 supports         'debian', '>= 6.0'
 recipe           'resolvconf', 'Installs and configures resolvconf package'

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -62,6 +62,7 @@ action :create do
   
   template '/etc/resolvconf/interface-order' do
     source 'interface-order.erb'
+    cookbook 'resolvconf'
     variables(
       :interfaces => new_resource.interface_order
       )

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -63,7 +63,7 @@ action :create do
   template '/etc/resolvconf/interface-order' do
     source 'interface-order.erb'
     variables(
-      :interfaces => node['resolvconf']['interface-order']
+      :interfaces => new_resource.interface_order
       )
     notifies :run, "execute[resolvconf -u]"
   end

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -32,6 +32,11 @@ attribute :clear_dns_from_interfaces,
           kind_of: [TrueClass, FalseClass],
           default: node['resolvconf']['clear-dns-from-interfaces']
 
+# set interface order file in /etc/resolvconf/interface-order
+attribute :interface_order, 
+          kind_of: [Array], 
+          default: node['resolvconf']['interface-order']
+
 # These elements will be placed in the corresponding file in /etc/resolvconf/resolv.conf.d/
 attribute :head, kind_of: [Array, String], default: node['resolvconf']['head']
 attribute :base, kind_of: [Array, String], default: node['resolvconf']['base']

--- a/templates/default/interface-order.erb
+++ b/templates/default/interface-order.erb
@@ -1,0 +1,6 @@
+# interface-order(5)
+# This file is managed by Chef all changes will be overwritten!
+#
+<% @interfaces.each do |interface| %>
+<%= interface %>
+<% end %>


### PR DESCRIPTION
There was an issue where resolvconf -u was not called when the LWRP was called, this resulted in a stale resolv.conf file. Instead to resolve this I used notify on the resources. 

interface-order was also left untouched meaning that resolvconf inherited dns servers from the interfaces configuration, it can now be overridden by the attribute.

I would suggest versioning this as a 1.0.0 to air on the side of caution, as it will force an update of resolvconf and could mess with peoples settings if this had not been called before.