### PR TITLE
Switch LWRP to use_inline_resources (resolvconf -u + notifications).

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -18,6 +18,12 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+# Converging the resource in a sub chef-run will ensure that:
+# - `resolvconf -u` is invoked as soon as this resource is converged.
+#   see https://github.com/chr4-cookbooks/resolvconf/issues/10
+# - callers are notified when (any of the internal resources is) updated
+use_inline_resources
+
 action :create do
   options = {}
   options['head'] = Array(new_resource.head)


### PR DESCRIPTION
My attempt at solving #10.

Please note that the PR uses [use_inline_resources](https://docs.chef.io/lwrp_custom_provider.html#use-inline-resources), which implies that the cookbook now requires chef >= 11.0. Feel free to document in README.md if you merge this PR.

The PR also implicitly restores the feature to notify the caller when the resolvconf resource is updated (new_resource.updated_by_last_action), which was lost in the same changeset that created #10.

I have tested manually that this restores the 0.2.6 behavior of running `resolvconf -u` after the LWRP has converged successfully, and not at the end of the chef-run.