### PR TITLE
Removing default nameservers

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -27,7 +27,7 @@ default['resolvconf']['base'] = []
 default['resolvconf']['tail'] = []
 
 # Shortcuts for specify /etc/resolv.conf options (will be added to node['resolvconf']['base'])
-default['resolvconf']['nameserver'] = %w(208.67.222.222 208.67.220.220) # OpenDNS
+default['resolvconf']['nameserver'] = []  # default empty else chef merges with any user provided ones
 default['resolvconf']['search'] = node['domain']
 default['resolvconf']['sortlist'] = []
 default['resolvconf']['options'] = []


### PR DESCRIPTION
As arrays are merged on attribute resolution rather than user provided ones taking precedence this can lead to confusion on the resulting resolv.conf including more than just expected provided servers

See:
http://devopsblues.com/how-to-overwrite-attribute-array-elements-instead-of-merging-in-chef/